### PR TITLE
ソーシャルPLUS ID をユニークにした

### DIFF
--- a/Schemafile
+++ b/Schemafile
@@ -53,7 +53,8 @@ create_table "users", force: :cascade do |t|
   t.datetime "updated_at",                 null: false
   t.text     "image_url"
   t.integer  "role",           default: 0, null: false
-  t.string   "socialplus_uid"
+  t.string   "socialplus_uid",             null: false
+  t.index ["socialplus_uid"], name: "index_users_on_socialplus_uid", using: :btree
 end
 
 add_foreign_key "accounts", "users", name: "accounts_belongs_to_users"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,12 @@
 # **`updated_at`**      | `datetime`         | `not null`
 # **`image_url`**       | `text`             |
 # **`role`**            | `integer`          | `default("user"), not null`
-# **`socialplus_uid`**  | `string`           |
+# **`socialplus_uid`**  | `string`           | `not null`
+#
+# ### Indexes
+#
+# * `index_users_on_socialplus_uid`:
+#     * **`socialplus_uid`**
 #
 
 class User < ApplicationRecord

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,7 +12,12 @@
 # **`updated_at`**      | `datetime`         | `not null`
 # **`image_url`**       | `text`             |
 # **`role`**            | `integer`          | `default("user"), not null`
-# **`socialplus_uid`**  | `string`           |
+# **`socialplus_uid`**  | `string`           | `not null`
+#
+# ### Indexes
+#
+# * `index_users_on_socialplus_uid`:
+#     * **`socialplus_uid`**
 #
 
 FactoryGirl.define do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,7 +12,12 @@
 # **`updated_at`**      | `datetime`         | `not null`
 # **`image_url`**       | `text`             |
 # **`role`**            | `integer`          | `default("user"), not null`
-# **`socialplus_uid`**  | `string`           |
+# **`socialplus_uid`**  | `string`           | `not null`
+#
+# ### Indexes
+#
+# * `index_users_on_socialplus_uid`:
+#     * **`socialplus_uid`**
 #
 
 require 'rails_helper'


### PR DESCRIPTION
#39 の続き。
一度に行うと、migration ができなくなるので PR をわけた。